### PR TITLE
Support configuring extract command user/group.

### DIFF
--- a/lib/puppet/provider/archive/default.rb
+++ b/lib/puppet/provider/archive/default.rb
@@ -96,7 +96,14 @@ Puppet::Type.type(:archive).provide(:default) do
   def extract
     if resource[:extract] == :true
       raise(ArgumentError, "missing archive extract_path") unless resource[:extract_path]
-      PuppetX::Bodeco::Archive.new(archive_filepath).extract(resource[:extract_path], nil, resource[:extract_flags])
+      PuppetX::Bodeco::Archive.new(archive_filepath).
+        extract(
+          resource[:extract_path],
+          :custom_command => resource[:extract_command],
+          :options => resource[:extract_flags],
+          :uid => resource[:user],
+          :gid => resource[:group],
+        )
     end
   end
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -140,9 +140,19 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:username) do
+    desc "source file access username"
   end
 
   newparam(:password) do
+    desc "source file access password"
+  end
+
+  newparam(:user) do
+    desc "extract command user (using this option will configure the archive file permission to 0644 so the user can read the file)."
+  end
+
+  newparam(:group) do
+    desc "extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file)."
   end
 
   autorequire(:package) do

--- a/lib/puppet_x/bodeco/archive.rb
+++ b/lib/puppet_x/bodeco/archive.rb
@@ -25,7 +25,16 @@ module PuppetX
         end
       end
 
-      def extract(path = root_dir, custom_command = nil, options = '')
+      def extract(path = root_dir, opts = {})
+        opts = {
+          :custom_command => nil,
+          :options => '',
+          :uid => nil,
+          :gid => nil,
+        }.merge(opts)
+
+        custom_command = opts.fetch(:custom_command, nil)
+        options = opts.fetch(:options)
         Dir.chdir(path) do
           if custom_command
             if custom_command =~ /%s/
@@ -38,7 +47,8 @@ module PuppetX
           end
 
           Puppet.debug("Archive extracting #{@file} in #{path}: #{cmd}")
-          Puppet::Util::Execution.execute(cmd)
+          File.chmod(0644, @file) if opts[:uid] || opts[:gid]
+          Puppet::Util::Execution.execute(cmd, :uid => opts[:uid], :gid => opts[:gid])
         end
       end
 

--- a/tests/archive.pp
+++ b/tests/archive.pp
@@ -9,4 +9,6 @@ archive { '/tmp/jta-1.1.jar':
   checksum_type => 'sha1',
   creates       => '/tmp/javax',
   cleanup       => true,
+  user          => 'vagrant',
+  group         => 'vagrant',
 }


### PR DESCRIPTION
In order to extract the file, we need to manage the file permission.
Setting file ownership is requires uid/gid and not the username, and
some serious complexity in Windows. This will do for now.

Fix #22