### PR TITLE
Issue #45 - set the namevar to be full path to file

### DIFF
--- a/lib/puppet/provider/archive/default.rb
+++ b/lib/puppet/provider/archive/default.rb
@@ -42,7 +42,8 @@ Puppet::Type.type(:archive).provide(:default) do
   end
 
   def download(archive_filepath)
-    tempfile = Tempfile.new(resource[:name])
+    require 'pathname'
+    tempfile = Tempfile.new(Pathname.new(resource[:name]).basename.to_s)
     temppath = tempfile.path
     tempfile.close!
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -53,7 +53,6 @@ Puppet::Type.newtype(:archive) do
         require 'pathname'
         filepath = Pathname.new(value)
         resource[:path] = filepath.to_s
-        filepath.basename.to_s
       else
         value
       end


### PR DESCRIPTION
This resolves the duplicate alias for the resources by not stripping the
directory off for the namevar. 
Stripping it off during the creation of the tempfile keeps current
functionality for the tempfile creation.

