### PR TITLE
Release 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ matrix:
   include:
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.0.0
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 sudo: false
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##2015/4/23 - 0.3.0
+
+* Fix Puppet 4 compatability issues
+* Fix archive namevar to use path
+
 ##2015/3/5 - 0.2.2
 
 * add FTP and File support

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Archive module dependency is managed by the archive class. By default 7zip is in
 
 ```puppet
 class { 'archive':
-  7zip_name     => '7-Zip 9.20 (x64 edition)',
-  7zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
-  7zip_provider => 'windows',
+  sevenzip_name     => '7-Zip 9.20 (x64 edition)',
+  sevenzip_source   => 'C:/Windows/Temp/7z920-x64.msi',
+  sevenzip_provider => 'windows',
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Archive module dependency is managed by the archive class. By default 7zip is in
 
 ```puppet
 class { 'archive':
-  sevenzip_name     => '7-Zip 9.20 (x64 edition)',
-  sevenzip_source   => 'C:/Windows/Temp/7z920-x64.msi',
-  sevenzip_provider => 'windows',
+  seven_zip_name     => '7-Zip 9.20 (x64 edition)',
+  seven_zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
+  seven_zip_provider => 'windows',
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 [![Puppet Forge](http://img.shields.io/puppetforge/v/nanliu/archive.svg)](https://forge.puppetlabs.com/nanliu/archive)
 [![Build Status](https://travis-ci.org/nanliu/puppet-archive.png)](https://travis-ci.org/nanliu/puppet-archive)
 
+## Warning
+
+Release 0.3.x contains breaking changes
+
+* The parameter 7zip have been changed to seven_zip to conform to Puppet 4.x variable name requirements.
+
 #### Table of Contents
 
 1. [Overview](#overview)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Release 0.3.x contains breaking changes
 
 * The parameter 7zip have been changed to seven_zip to conform to Puppet 4.x variable name requirements.
+* The namevar name have been changed to path to allow files with the same filename to exists in different filepath.
 
 #### Table of Contents
 
@@ -91,6 +92,29 @@ class { 'archive':
 
 ### Resources
 
+#### Archive
+
+* `ensure`: whether archive file should be present/absent (default: present)
+* `path`: namevar, archive file fully qualified file path.
+* `filename`: archive file name (derived from path).
+* `source`: archive file source, supports http|https|ftp|file uri.
+* `username`: username to download source file.
+* `password`: password to download source file.
+* `cookie`: archive file download cookie.
+* `checksum_type` archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512). (default: none)
+* `checksum`: archive file checksum (match checksum_type)
+* `checksum_source`: archive file checksum source (instead of specify checksum)
+* `checksum_verify`: whether checksum be verified (true|false). (default: true)
+* `extract`: whether archive be extracted after download (true|false). (default: false)
+* `extract_path`: target folder path to extract archive.
+* `extract_command`: custom extraction command ('tar xvf example.tar.gz'), also support sprintf format ('tar xvf %s') which will be processed with the filename: sprintf('tar xvf %s', filename)
+* `extract_flags`: custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}.
+* `user`: extract command user (using this option will configure the archive file permission to 0644 so the user can read the file).
+* `group`: extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file).
+* `cleanup`: whether archive file be removed after extraction (true|false). (default: true)
+* `creates`: if file/directory exists, will not download/extract archive.
+
+#### Example:
 ```puppet
 archive { '/tmp/jta-1.1.jar':
   ensure        => present,

--- a/lib/puppet/provider/archive/default.rb
+++ b/lib/puppet/provider/archive/default.rb
@@ -9,6 +9,7 @@ rescue LoadError
   require File.join archive.path, 'lib/puppet_x/bodeco/util'
 end
 
+require 'securerandom'
 require 'tempfile'
 
 Puppet::Type.type(:archive).provide(:default) do
@@ -41,8 +42,16 @@ Puppet::Type.type(:archive).provide(:default) do
     resource[:path]
   end
 
+  def tempfile_name
+    if resource[:checksum] == 'none'
+      "#{resource[:filename]}_#{SecureRandom.base64}"
+    else
+      "#{resource[:filename]}_#{resource[:checksum]}"
+    end
+  end
+
   def download(archive_filepath)
-    tempfile = Tempfile.new(resource[:name])
+    tempfile = Tempfile.new(tempfile_name)
     temppath = tempfile.path
     tempfile.close!
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'uri'
 require 'puppet/util'
 
@@ -5,6 +6,8 @@ Puppet::Type.newtype(:archive) do
   @doc = 'Manage archive file download, extraction, and cleanup.'
 
   ensurable do
+    desc "whether archive file should be present/absent (default: present)"
+
     newvalue(:present) do
       provider.create
     end
@@ -46,28 +49,27 @@ Puppet::Type.newtype(:archive) do
     end
   end
 
-  newparam(:name, :namevar => true) do
-    desc "archive file name (accepts absolute target filepath)"
-    munge do |value|
-      if Puppet::Util.absolute_path? value
-        require 'pathname'
-        filepath = Pathname.new(value)
-        resource[:path] = filepath.to_s
-        filepath.basename.to_s
-      else
-        value
+  newparam(:path, :namevar => true) do
+    desc "namevar, archive file fully qualified file path."
+    validate do |value|
+      unless Puppet::Util.absolute_path? value
+        raise ArgumentError, "archive path must be absolute: #{value}"
       end
     end
   end
 
+  newparam(:filename) do
+    desc "archive file name (derived from path)."
+  end
+
   newparam(:extract) do
-    desc "should archive be extracted after download (true|false)"
+    desc "should archive be extracted after download (true|false)."
     newvalues(:true, :false)
     defaultto(:false)
   end
 
   newparam(:extract_path) do
-    desc "target path to extract archive"
+    desc "target folder path to extract archive."
     validate do |value|
       unless Puppet::Util.absolute_path? value
         raise ArgumentError, "archive extract_path must be absolute: #{value}"
@@ -80,21 +82,13 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:extract_flags) do
-    desc "custom extract options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
+    desc "custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
     defaultto(:undef)
   end
 
-  newparam(:path) do
-    desc "archive file path"
-    validate do |value|
-      unless Puppet::Util.absolute_path? value
-        raise ArgumentError, "archive path must be absolute: #{value}"
-      end
-    end
-  end
 
   newproperty(:creates) do
-    desc "if file/directory exists, will not download/extract archive"
+    desc "if file/directory exists, will not download/extract archive."
 
     def should_to_s(value)
       "extracting in #{resource[:extract_path]} to create #{value}"
@@ -102,13 +96,13 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:cleanup) do
-    desc "should archive file be removed after extraction (true|false)"
+    desc "whether archive file be removed after extraction (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end
 
   newparam(:source) do
-    desc "archive source file, supports http/https/ftp/file."
+    desc "archive file source, supports http|https|ftp|file uri."
     validate do |value|
       unless value =~ URI.regexp(['http', 'https', 'file', 'ftp'])
         raise ArgumentError, "invalid source url: #{value}"
@@ -117,36 +111,36 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:cookie) do
-    desc "archive download cookie."
+    desc "archive file download cookie."
   end
 
   newparam(:checksum) do
-    desc "archive checksum"
+    desc "archive file checksum (match checksum_type)."
     newvalues(/\b[0-9a-f]{5,64}\b/)
   end
 
   newparam(:checksum_source) do
-    desc "archive checksum source (instead of specify checksum)"
+    desc "archive file checksum source (instead of specify checksum)"
   end
 
   newparam(:checksum_type) do
-    desc "archive checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)"
+    desc "archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)."
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
     defaultto(:none)
   end
 
   newparam(:checksum_verify) do
-    desc "should checksum be verified (true|false)"
+    desc "whether checksum be verified (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end
 
   newparam(:username) do
-    desc "username to download source file"
+    desc "username to download source file."
   end
 
   newparam(:password) do
-    desc "password to download source file"
+    desc "password to download source file."
   end
 
   newparam(:user) do
@@ -162,14 +156,11 @@ Puppet::Type.newtype(:archive) do
   end
 
   autorequire(:file) do
-    self[:path]
-  end
-
-  autorequire(:file) do
-    self[:extract_path]
+    [ Pathname.new(self[:path]).parent.to_s, self[:extract_path] ]
   end
 
   validate do
-    raise(ArgumentError, "missing archive file path") unless self[:path]
+    filepath = Pathname.new(self[:path])
+    self[:filename] = filepath.basename.to_s
   end
 end

--- a/manifests/artifactory.pp
+++ b/manifests/artifactory.pp
@@ -29,7 +29,7 @@ define archive::artifactory (
   $file_url = "${art_url}/${url_path}"
   $sha1_url = "${art_url}/api/storage/${url_path}"
 
-  archive { $name:
+  archive { $file_path:
     ensure        => $ensure,
     path          => $file_path,
     extract       => $extract,
@@ -49,6 +49,6 @@ define archive::artifactory (
     owner   => $file_owner,
     group   => $file_group,
     mode    => $file_mode,
-    require => Archive[$name],
+    require => Archive[$file_path],
   }
 }

--- a/manifests/go.pp
+++ b/manifests/go.pp
@@ -32,7 +32,7 @@ define archive::go (
   $file_url = "${go_url}/${url_path}"
   $md5_url = "${go_url}/${md5_url_path}"
 
-  archive { $name:
+  archive { $file_path:
     ensure        => $ensure,
     path          => $file_path,
     extract       => $extract,
@@ -54,6 +54,6 @@ define archive::go (
     owner   => $file_owner,
     group   => $file_group,
     mode    => $file_mode,
-    require => Archive[$name],
+    require => Archive[$file_path],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,15 +5,15 @@
 # == Examples:
 #
 # class { 'archive':
-#   7zip_name     => '7-Zip 9.20 (x64 edition)',
-#   7zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
-#   7zip_provider => 'windows',
+#   sevenzip_name     => '7-Zip 9.20 (x64 edition)',
+#   sevenzip_source   => 'C:/Windows/Temp/7z920-x64.msi',
+#   sevenzip_provider => 'windows',
 # }
 #
 class archive (
-  $7zip_name     = $archive::params::7zip_name,
-  $7zip_provider = $archive::params::7zip_provider,
-  $7zip_source   = undef,
+  $sevenzip_name     = $archive::params::sevenzip_name,
+  $sevenzip_provider = $archive::params::sevenzip_provider,
+  $sevenzip_source   = undef,
 ) inherits archive::params {
   package { 'faraday':
     ensure   => present,
@@ -25,12 +25,12 @@ class archive (
     provider => $archive::params::gem_provider,
   }
 
-  if $::osfamily == 'Windows' and $7zip_provider {
+  if $::osfamily == 'Windows' and $sevenzip_provider {
     package { '7zip':
       ensure   => present,
-      name     => $7zip_name,
-      source   => $7zip_source,
-      provider => $7zip_provider,
+      name     => $sevenzip_name,
+      source   => $sevenzip_source,
+      provider => $sevenzip_provider,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,15 +5,15 @@
 # == Examples:
 #
 # class { 'archive':
-#   sevenzip_name     => '7-Zip 9.20 (x64 edition)',
-#   sevenzip_source   => 'C:/Windows/Temp/7z920-x64.msi',
-#   sevenzip_provider => 'windows',
+#   seven_zip_name     => '7-Zip 9.20 (x64 edition)',
+#   seven_zip_source   => 'C:/Windows/Temp/7z920-x64.msi',
+#   seven_zip_provider => 'windows',
 # }
 #
 class archive (
-  $sevenzip_name     = $archive::params::sevenzip_name,
-  $sevenzip_provider = $archive::params::sevenzip_provider,
-  $sevenzip_source   = undef,
+  $seven_zip_name     = $archive::params::seven_zip_name,
+  $seven_zip_provider = $archive::params::seven_zip_provider,
+  $seven_zip_source   = undef,
 ) inherits archive::params {
   package { 'faraday':
     ensure   => present,
@@ -25,12 +25,12 @@ class archive (
     provider => $archive::params::gem_provider,
   }
 
-  if $::osfamily == 'Windows' and $sevenzip_provider {
+  if $::osfamily == 'Windows' and $seven_zip_provider {
     package { '7zip':
       ensure   => present,
-      name     => $sevenzip_name,
-      source   => $sevenzip_source,
-      provider => $sevenzip_provider,
+      name     => $seven_zip_name,
+      source   => $seven_zip_source,
+      provider => $seven_zip_provider,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class archive (
     provider => $archive::params::gem_provider,
   }
 
-  if $::osfamily == 'Windows' and $seven_zip_provider {
+  if $::osfamily == 'Windows' and !($seven_zip_provider in ['', undef]) {
     package { '7zip':
       ensure   => present,
       name     => $seven_zip_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,18 +2,18 @@
 class archive::params {
   case $::osfamily {
     default: {
-      $path      = '/opt/staging'
-      $owner     = '0'
-      $group     = '0'
-      $mode      = '0640'
+      $path  = '/opt/staging'
+      $owner = '0'
+      $group = '0'
+      $mode  = '0640'
     }
     'Windows': {
-      $path              = $::staging_windir
-      $owner             = 'S-1-5-32-544' # Adminstrators
-      $group             = 'S-1-5-18'     # SYSTEM
-      $mode              = '0640'
-      $sevenzip_name     = '7zip'
-      $sevenzip_provider = 'chocolatey'
+      $path               = $::staging_windir
+      $owner              = 'S-1-5-32-544' # Adminstrators
+      $group              = 'S-1-5-18'     # SYSTEM
+      $mode               = '0640'
+      $seven_zip_name     = '7zip'
+      $seven_zip_provider = 'chocolatey'
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,12 +8,12 @@ class archive::params {
       $mode      = '0640'
     }
     'Windows': {
-      $path          = $::staging_windir
-      $owner         = 'S-1-5-32-544' # Adminstrators
-      $group         = 'S-1-5-18'     # SYSTEM
-      $mode          = '0640'
-      $7zip_name     = '7zip'
-      $7zip_provider = 'chocolatey'
+      $path              = $::staging_windir
+      $owner             = 'S-1-5-32-544' # Adminstrators
+      $group             = 'S-1-5-18'     # SYSTEM
+      $mode              = '0640'
+      $sevenzip_name     = '7zip'
+      $sevenzip_provider = 'chocolatey'
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -96,7 +96,7 @@
     }
   ],
   "name": "nanliu-archive",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "source": "http://github.com/nanliu/puppet-archive",
   "author": "Nan Liu",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
       "operatingsystemrelease": [
         "4",
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -13,7 +14,8 @@
       "operatingsystemrelease": [
         "4",
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -21,7 +23,8 @@
       "operatingsystemrelease": [
         "4",
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -29,7 +32,8 @@
       "operatingsystemrelease": [
         "4",
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -88,7 +92,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=2.7.0 <4.0.0"
+      "version_requirement": ">=2.7.0"
     }
   ],
   "name": "nanliu-archive",

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -49,9 +49,9 @@ describe 'archive' do
     let(:facts) {{ :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' }}
 
     let(:params) {{
-      :'sevenzip_name'     => '7-Zip 9.20 (x64 edition)',
-      :'sevenzip_source'   => 'C:/Windows/Temp/7z920-x64.msi',
-      :'sevenzip_provider' => 'windows'
+      :'seven_zip_name'     => '7-Zip 9.20 (x64 edition)',
+      :'seven_zip_source'   => 'C:/Windows/Temp/7z920-x64.msi',
+      :'seven_zip_provider' => 'windows'
     }}
 
     it { should contain_package('faraday').with_provider('gem') }
@@ -69,7 +69,7 @@ describe 'archive' do
     let(:facts) {{ :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' }}
 
     let(:params) {{
-      :'sevenzip_provider' => ''
+      :'seven_zip_provider' => ''
     }}
 
     it { should contain_package('faraday').with_provider('gem') }

--- a/spec/classes/archive_spec.rb
+++ b/spec/classes/archive_spec.rb
@@ -49,9 +49,9 @@ describe 'archive' do
     let(:facts) {{ :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' }}
 
     let(:params) {{
-      :'7zip_name'     => '7-Zip 9.20 (x64 edition)',
-      :'7zip_source'   => 'C:/Windows/Temp/7z920-x64.msi',
-      :'7zip_provider' => 'windows'
+      :'sevenzip_name'     => '7-Zip 9.20 (x64 edition)',
+      :'sevenzip_source'   => 'C:/Windows/Temp/7z920-x64.msi',
+      :'sevenzip_provider' => 'windows'
     }}
 
     it { should contain_package('faraday').with_provider('gem') }
@@ -69,7 +69,7 @@ describe 'archive' do
     let(:facts) {{ :osfamily => 'Windows', :puppetversion => '3.4.3 (Puppet Enterprise 3.2.3)' }}
 
     let(:params) {{
-      :'7zip_provider' => ''
+      :'sevenzip_provider' => ''
     }}
 
     it { should contain_package('faraday').with_provider('gem') }

--- a/spec/defines/artifactory_spec.rb
+++ b/spec/defines/artifactory_spec.rb
@@ -47,7 +47,7 @@ describe 'archive::artifactory' do
       :mode => '0400',
     }}
 
-    it { should contain_archive('example.zip').with({
+    it { should contain_archive('/opt/app/example.zip').with({
         :path => '/opt/app/example.zip',
         :source => 'http://home.lan:8081/artifactory/path/example.zip',
         :checksum => '0d4f4b4b039c10917cfc49f6f6be71e4',
@@ -59,7 +59,7 @@ describe 'archive::artifactory' do
         :owner => 'app',
         :group => 'app',
         :mode => '0400',
-        :require => 'Archive[example.zip]',
+        :require => 'Archive[/opt/app/example.zip]',
       })
     }
   end

--- a/spec/defines/go_spec.rb
+++ b/spec/defines/go_spec.rb
@@ -55,7 +55,7 @@ describe 'archive::go' do
       :mode => '0400',
     }}
 
-    it { should contain_archive('example.zip').with({
+    it { should contain_archive('/opt/app/example.zip').with({
         :path => '/opt/app/example.zip',
         :source => 'http://home.lan:8081/go/example.zip',
         :checksum => '0d4f4b4b039c10917cfc49f6f6be71e4',
@@ -67,7 +67,7 @@ describe 'archive::go' do
         :owner => 'app',
         :group => 'app',
         :mode => '0400',
-        :require => 'Archive[example.zip]',
+        :require => 'Archive[/opt/app/example.zip]',
       })
     }
   end

--- a/spec/unit/puppet/provider/archive/archive_spec.rb
+++ b/spec/unit/puppet/provider/archive/archive_spec.rb
@@ -21,7 +21,7 @@ describe archive_provider do
 
   it '#checksum?' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       FileUtils.cp(zipfile, resource[:path])
 
       resource[:checksum] = '377ec712d7fdb7266221db3441e3af2055448ead'
@@ -40,7 +40,7 @@ describe archive_provider do
 
   it '#extract' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -55,7 +55,7 @@ describe archive_provider do
 
   it '#extracted?' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -71,7 +71,7 @@ describe archive_provider do
 
   it '#cleanup' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -88,7 +88,7 @@ describe archive_provider do
 
   it '#create' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -3,17 +3,18 @@ require 'puppet'
 
 describe Puppet::Type::type(:archive) do
   let(:resource) { Puppet::Type.type(:archive).new(
-    :name => '/tmp/example.zip',
+    :path   => '/tmp/example.zip',
     :source => 'http://home.lan/example.zip'
   )}
 
   it 'resource defaults' do
-    resource[:name].should eq 'example.zip'
+    resource[:path].should eq '/tmp/example.zip'
+    resource[:name].should eq '/tmp/example.zip'
+    resource[:filename].should eq 'example.zip'
     resource[:extract].should eq :false
     resource[:cleanup].should eq :true
     resource[:checksum_type].should eq :none
     resource[:checksum_verify].should eq :true
-    resource[:path].should eq '/tmp/example.zip'
     resource[:extract_flags].should eq :undef
   end
 
@@ -59,5 +60,32 @@ describe Puppet::Type::type(:archive) do
     expect {
       resource[:checksum_type] = :crc32
     }.to raise_error(Puppet::Error, /Invalid value/)
+  end
+
+  describe 'autorequire parent path' do
+    # Need to import puppet's crazy monkey patch to test:
+    class Object
+      alias :must :should
+      alias :must_not :should_not
+    end
+
+    before :each do
+      @file_tmp = Puppet::Type.type(:file).new(:name => '/tmp')
+      @catalog = Puppet::Resource::Catalog.new
+      @catalog.add_resource @file_tmp
+    end
+
+    it 'should require archive parent' do
+      example_archive = described_class.new(
+        :path   => '/tmp/example.zip',
+        :source => 'http://home.lan/example.zip'
+      )
+      @catalog.add_resource example_archive
+
+      req = example_archive.autorequire
+      req.size.should == 1
+      req[0].target.must == example_archive
+      req[0].source.must == @file_tmp
+    end
   end
 end

--- a/tests/duplicate.pp
+++ b/tests/duplicate.pp
@@ -1,0 +1,26 @@
+$source_file = '/tmp/source'
+
+file { $source_file:
+  ensure  => file,
+  content => 'this is a test',
+}
+
+file { ['/tmp/result1', '/tmp/result2']:
+  ensure => directory,
+}
+
+archive { '/tmp/result1/result':
+  ensure  => present,
+  name    => '/tmp/result1/result',
+  source  => "file://${source_file}",
+  extract => false,
+  require => File[$source_file],
+}
+
+archive { '/tmp/result2/result':
+  ensure  => present,
+  name    => '/tmp/result2/result',
+  source  => "file://${source_file}",
+  extract => false,
+  require => File[$source_file],
+}


### PR DESCRIPTION
* Fix 7zip variable name for Puppet 4.
* Fix archive uniqueness by using path as namevar.
* Update documentation and support files.