### PR TITLE
Fix archive so namevar is unique.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ class { 'archive':
 
 ### Resources
 
+#### Archive
+
+* `ensure`: whether archive file should be present/absent (default: present)
+* `path`: namevar, archive file fully qualified file path.
+* `filename`: archive file name (derived from path).
+* `source`: archive file source, supports http|https|ftp|file uri.
+* `username`: username to download source file.
+* `password`: password to download source file.
+* `cookie`: archive file download cookie.
+* `checksum_type` archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512). (default: none)
+* `checksum`: archive file checksum (match checksum_type)
+* `checksum_source`: archive file checksum source (instead of specify checksum)
+* `checksum_verify`: whether checksum be verified (true|false). (default: true)
+* `extract`: whether archive be extracted after download (true|false). (default: false)
+* `extract_path`: target folder path to extract archive.
+* `extract_command`: custom extraction command ('tar xvf example.tar.gz'), also support sprintf format ('tar xvf %s') which will be processed with the filename: sprintf('tar xvf %s', filename)
+* `extract_flags`: custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}.
+* `user`: extract command user (using this option will configure the archive file permission to 0644 so the user can read the file).
+* `group`: extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file).
+* `cleanup`: whether archive file be removed after extraction (true|false). (default: true)
+* `creates`: if file/directory exists, will not download/extract archive.
+
+#### Example:
 ```puppet
 archive { '/tmp/jta-1.1.jar':
   ensure        => present,

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Release 0.3.x contains breaking changes
 
 * The parameter 7zip have been changed to seven_zip to conform to Puppet 4.x variable name requirements.
+* The namevar name have been changed to path to allow files with the same filename to exists in different filepath.
 
 #### Table of Contents
 

--- a/lib/puppet/provider/archive/default.rb
+++ b/lib/puppet/provider/archive/default.rb
@@ -9,6 +9,7 @@ rescue LoadError
   require File.join archive.path, 'lib/puppet_x/bodeco/util'
 end
 
+require 'securerandom'
 require 'tempfile'
 
 Puppet::Type.type(:archive).provide(:default) do
@@ -41,8 +42,16 @@ Puppet::Type.type(:archive).provide(:default) do
     resource[:path]
   end
 
+  def tempfile_name
+    if resource[:checksum] == 'none'
+      "#{resource[:filename]}_#{SecureRandom.base64}"
+    else
+      "#{resource[:filename]}_#{resource[:checksum]}"
+    end
+  end
+
   def download(archive_filepath)
-    tempfile = Tempfile.new(resource[:name])
+    tempfile = Tempfile.new(tempfile_name)
     temppath = tempfile.path
     tempfile.close!
 

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -156,11 +156,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   autorequire(:file) do
-    Pathname.new(self[:path]).parent.to_s
-  end
-
-  autorequire(:file) do
-    self[:extract_path]
+    [ Pathname.new(self[:path]).parent.to_s, self[:extract_path] ]
   end
 
   validate do

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:path, :namevar => true) do
-    desc "archive file fully qualified file path."
+    desc "namevar, archive file fully qualified file path."
     validate do |value|
       unless Puppet::Util.absolute_path? value
         raise ArgumentError, "archive path must be absolute: #{value}"
@@ -59,17 +59,17 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:filename) do
-    desc "archive filename."
+    desc "archive file name (derived from path)."
   end
 
   newparam(:extract) do
-    desc "should archive be extracted after download (true|false)"
+    desc "should archive be extracted after download (true|false)."
     newvalues(:true, :false)
     defaultto(:false)
   end
 
   newparam(:extract_path) do
-    desc "target path to extract archive"
+    desc "target folder path to extract archive."
     validate do |value|
       unless Puppet::Util.absolute_path? value
         raise ArgumentError, "archive extract_path must be absolute: #{value}"
@@ -82,13 +82,13 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:extract_flags) do
-    desc "custom extract options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
+    desc "custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}."
     defaultto(:undef)
   end
 
 
   newproperty(:creates) do
-    desc "if file/directory exists, will not download/extract archive"
+    desc "if file/directory exists, will not download/extract archive."
 
     def should_to_s(value)
       "extracting in #{resource[:extract_path]} to create #{value}"
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:cleanup) do
-    desc "should archive file be removed after extraction (true|false)"
+    desc "whether archive file be removed after extraction (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end
@@ -115,7 +115,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:checksum) do
-    desc "archive file checksum (match checksum_type)"
+    desc "archive file checksum (match checksum_type)."
     newvalues(/\b[0-9a-f]{5,64}\b/)
   end
 
@@ -124,23 +124,23 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:checksum_type) do
-    desc "archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)"
+    desc "archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512)."
     newvalues(:none, :md5, :sha1, :sha2, :sha256, :sha384, :sha512)
     defaultto(:none)
   end
 
   newparam(:checksum_verify) do
-    desc "whether checksum be verified (true|false)"
+    desc "whether checksum be verified (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end
 
   newparam(:username) do
-    desc "username to download source file"
+    desc "username to download source file."
   end
 
   newparam(:password) do
-    desc "password to download source file"
+    desc "password to download source file."
   end
 
   newparam(:user) do

--- a/manifests/artifactory.pp
+++ b/manifests/artifactory.pp
@@ -29,7 +29,7 @@ define archive::artifactory (
   $file_url = "${art_url}/${url_path}"
   $sha1_url = "${art_url}/api/storage/${url_path}"
 
-  archive { $name:
+  archive { $file_path:
     ensure        => $ensure,
     path          => $file_path,
     extract       => $extract,
@@ -49,6 +49,6 @@ define archive::artifactory (
     owner   => $file_owner,
     group   => $file_group,
     mode    => $file_mode,
-    require => Archive[$name],
+    require => Archive[$file_path],
   }
 }

--- a/manifests/go.pp
+++ b/manifests/go.pp
@@ -32,7 +32,7 @@ define archive::go (
   $file_url = "${go_url}/${url_path}"
   $md5_url = "${go_url}/${md5_url_path}"
 
-  archive { $name:
+  archive { $file_path:
     ensure        => $ensure,
     path          => $file_path,
     extract       => $extract,
@@ -54,6 +54,6 @@ define archive::go (
     owner   => $file_owner,
     group   => $file_group,
     mode    => $file_mode,
-    require => Archive[$name],
+    require => Archive[$file_path],
   }
 }

--- a/spec/defines/artifactory_spec.rb
+++ b/spec/defines/artifactory_spec.rb
@@ -47,7 +47,7 @@ describe 'archive::artifactory' do
       :mode => '0400',
     }}
 
-    it { should contain_archive('example.zip').with({
+    it { should contain_archive('/opt/app/example.zip').with({
         :path => '/opt/app/example.zip',
         :source => 'http://home.lan:8081/artifactory/path/example.zip',
         :checksum => '0d4f4b4b039c10917cfc49f6f6be71e4',
@@ -59,7 +59,7 @@ describe 'archive::artifactory' do
         :owner => 'app',
         :group => 'app',
         :mode => '0400',
-        :require => 'Archive[example.zip]',
+        :require => 'Archive[/opt/app/example.zip]',
       })
     }
   end

--- a/spec/defines/go_spec.rb
+++ b/spec/defines/go_spec.rb
@@ -55,7 +55,7 @@ describe 'archive::go' do
       :mode => '0400',
     }}
 
-    it { should contain_archive('example.zip').with({
+    it { should contain_archive('/opt/app/example.zip').with({
         :path => '/opt/app/example.zip',
         :source => 'http://home.lan:8081/go/example.zip',
         :checksum => '0d4f4b4b039c10917cfc49f6f6be71e4',
@@ -67,7 +67,7 @@ describe 'archive::go' do
         :owner => 'app',
         :group => 'app',
         :mode => '0400',
-        :require => 'Archive[example.zip]',
+        :require => 'Archive[/opt/app/example.zip]',
       })
     }
   end

--- a/spec/unit/puppet/provider/archive/archive_spec.rb
+++ b/spec/unit/puppet/provider/archive/archive_spec.rb
@@ -21,7 +21,7 @@ describe archive_provider do
 
   it '#checksum?' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       FileUtils.cp(zipfile, resource[:path])
 
       resource[:checksum] = '377ec712d7fdb7266221db3441e3af2055448ead'
@@ -40,7 +40,7 @@ describe archive_provider do
 
   it '#extract' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -55,7 +55,7 @@ describe archive_provider do
 
   it '#extracted?' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -71,7 +71,7 @@ describe archive_provider do
 
   it '#cleanup' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 
@@ -88,7 +88,7 @@ describe archive_provider do
 
   it '#create' do
     Dir.mktmpdir do |dir|
-      resource[:path] = File.join(dir, resource[:name])
+      resource[:path] = File.join(dir, resource[:filename])
       extracted_file = File.join(dir, 'test')
       FileUtils.cp(zipfile, resource[:path])
 

--- a/spec/unit/puppet/type/archive_spec.rb
+++ b/spec/unit/puppet/type/archive_spec.rb
@@ -3,17 +3,17 @@ require 'puppet'
 
 describe Puppet::Type::type(:archive) do
   let(:resource) { Puppet::Type.type(:archive).new(
-    :name => '/tmp/example.zip',
+    :path   => '/tmp/example.zip',
     :source => 'http://home.lan/example.zip'
   )}
 
   it 'resource defaults' do
-    resource[:name].should eq 'example.zip'
+    resource[:path].should eq '/tmp/example.zip'
+    resource[:filename].should eq 'example.zip'
     resource[:extract].should eq :false
     resource[:cleanup].should eq :true
     resource[:checksum_type].should eq :none
     resource[:checksum_verify].should eq :true
-    resource[:path].should eq '/tmp/example.zip'
     resource[:extract_flags].should eq :undef
   end
 

--- a/tests/duplicate.pp
+++ b/tests/duplicate.pp
@@ -1,0 +1,26 @@
+$source_file = '/tmp/source'
+
+file { $source_file:
+  ensure  => file,
+  content => 'this is a test',
+}
+
+file { ['/tmp/result1', '/tmp/result2']:
+  ensure => directory,
+}
+
+archive { '/tmp/result1/result':
+  ensure  => present,
+  name    => '/tmp/result1/result',
+  source  => "file://${source_file}",
+  extract => false,
+  require => File[$source_file],
+}
+
+archive { '/tmp/result2/result':
+  ensure  => present,
+  name    => '/tmp/result2/result',
+  source  => "file://${source_file}",
+  extract => false,
+  require => File[$source_file],
+}


### PR DESCRIPTION
Instead of using filename, we are now using fully qualified filepath to
identify archive files. This is a potentially backwards breaking change.