### PR TITLE
Add support for remote checksum url

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ class { 'archive':
 * `cookie`: archive file download cookie.
 * `checksum_type` archive file checksum type (none|md5|sha1|sha2|sh256|sha384|sha512). (default: none)
 * `checksum`: archive file checksum (match checksum_type)
-* `checksum_source`: archive file checksum source (instead of specify checksum)
-* `checksum_verify`: whether checksum be verified (true|false). (default: true)
-* `extract`: whether archive be extracted after download (true|false). (default: false)
+* `checksum_url`: archive file checksum source (instead of specify checksum)
+* `checksum_verify`: whether checksum will be verified (true|false). (default: true)
+* `extract`: whether archive will be extracted after download (true|false). (default: false)
 * `extract_path`: target folder path to extract archive.
 * `extract_command`: custom extraction command ('tar xvf example.tar.gz'), also support sprintf format ('tar xvf %s') which will be processed with the filename: sprintf('tar xvf %s', filename)
 * `extract_flags`: custom extraction options, this replaces the default flags. A string such as 'xvf' for a tar file would replace the default xf flag. A hash is useful when custom flags are needed for different platforms. {'tar' => 'xzf', '7z' => 'x -aot'}.
 * `user`: extract command user (using this option will configure the archive file permission to 0644 so the user can read the file).
 * `group`: extract command group (using this option will configure the archive file permisison to 0644 so the user can read the file).
-* `cleanup`: whether archive file be removed after extraction (true|false). (default: true)
+* `cleanup`: whether archive file will be removed after extraction (true|false). (default: true)
 * `creates`: if file/directory exists, will not download/extract archive.
 
 #### Example:

--- a/lib/puppet/provider/archive/default.rb
+++ b/lib/puppet/provider/archive/default.rb
@@ -59,6 +59,7 @@ Puppet::Type.type(:archive).provide(:default) do
 
     # conditionally verify checksum:
     if resource[:checksum_verify] == :true and resource[:checksum_type] != :none
+
       archive = PuppetX::Bodeco::Archive.new(temppath)
       raise(Puppet::Error, 'Download file checksum mismatch') unless archive.checksum(resource[:checksum_type]) == checksum
     end
@@ -79,8 +80,13 @@ Puppet::Type.type(:archive).provide(:default) do
   end
 
   def checksum
-    # TODO: || rest_get(resource[:checksum_url])
-    resource[:checksum]
+    resource[:checksum] || remote_checksum
+  end
+
+  def remote_checksum
+    if resource[:checksum_url]
+      @remote_checksum ||= PuppetX::Bodeco::Util.content(resource[:checksum_url], :username => resource[:username], :password => resource[:password], :cookie => resource[:cookie])
+    end
   end
 
   # Private: See if local archive checksum matches.

--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -63,7 +63,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:extract) do
-    desc "should archive be extracted after download (true|false)."
+    desc "whether archive will be extracted after download (true|false)."
     newvalues(:true, :false)
     defaultto(:false)
   end
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:cleanup) do
-    desc "whether archive file be removed after extraction (true|false)."
+    desc "whether archive file will be removed after extraction (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end
@@ -119,7 +119,7 @@ Puppet::Type.newtype(:archive) do
     newvalues(/\b[0-9a-f]{5,64}\b/)
   end
 
-  newparam(:checksum_source) do
+  newparam(:checksum_url) do
     desc "archive file checksum source (instead of specify checksum)"
   end
 
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:archive) do
   end
 
   newparam(:checksum_verify) do
-    desc "whether checksum be verified (true|false)."
+    desc "whether checksum wil be verified (true|false)."
     newvalues(:true, :false)
     defaultto(:true)
   end

--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -6,7 +6,13 @@ module PuppetX
       def self.download(url, filepath, options = {})
         uri = URI(url)
         @connection = PuppetX::Bodeco.const_get(uri.scheme.upcase).new("#{uri.scheme}://#{uri.host}:#{uri.port}", options)
-        @connection.download(uri.path, filepath)
+        @connection.download("#{uri.path}?#{uri.query}", filepath)
+      end
+
+      def self.content(url, filepath, options = {})
+        uri = URI(url)
+        @connection = PuppetX::Bodeco.const_get(uri.scheme.upcase).new("#{uri.scheme}://#{uri.host}:#{uri.port}", options)
+        @connection.content("#{uri.path}?#{uri.query}")
       end
     end
 
@@ -43,6 +49,12 @@ module PuppetX
         f.close
         File.unlink(file_path)
         raise $!, "Unable to download file #{url_path} from #{@connection.url_prefix}. #{$!}", $!.backtrace
+      end
+
+      def content(url_path)
+        @connection.get(url_path).body
+      rescue Faraday::Error::ClientError
+        raise $!, "Unable to retrieve content #{url_path} from #{@connection.url_prefix}. #{$!}", $!.backtrace
       end
     end
 

--- a/tests/remote_checksum.pp
+++ b/tests/remote_checksum.pp
@@ -1,0 +1,10 @@
+include 'archive'
+
+archive { '/tmp/hawtio-web-1.4.36.jar':
+  ensure        => present,
+  extract       => false,
+  extract_path  => '/tmp',
+  source        => 'https://oss.sonatype.org/service/local/artifact/maven/content?g=io.hawt&a=hawtio-web&v=1.4.36&p=war&r=releases',
+  checksum_url  => 'https://oss.sonatype.org/service/local/artifact/maven/content?g=io.hawt&a=hawtio-web&v=1.4.36&p=war.md5&r=releases',
+  checksum_type => 'md5',
+}


### PR DESCRIPTION
- Add support for url query for remote file.
- Fix type documentation.
- checksum_source was never used, so backwards compatible name change.
