### PR TITLE
puppet 4.2.1 rspec fix for Evaluation Error: Left match operand must result in a String value. Got an Undef Value.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class archive::params {
     }
   }
 
-  if $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
+  if $::puppetversion != undef and $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
     $gem_provider = 'pe_gem'
   } else {
     $gem_provider = 'gem'


### PR DESCRIPTION
Got this rspec error in puppet 4.2.1

  1) wildfly with defaults for all parameters should contain Class[wildfly]
     Failure/Error: it { should contain_class('wildfly') }
     Puppet::PreformattedError:
       Evaluation Error: Left match operand must result in a String value. Got an Undef Value. at /home/travis/build/biemond/biemond-wildfly/spec/fixtures/modules/archive/manifests/params.pp:20:6 on node testing-worker-linux-docker-cb95fe22-3221-linux-7.prod.travis-ci.org
