### PR TITLE
Explicitly set required params for strict_variables compatibility

### DIFF
--- a/lib/puppet_x/bodeco/util.rb
+++ b/lib/puppet_x/bodeco/util.rb
@@ -6,13 +6,21 @@ module PuppetX
       def self.download(url, filepath, options = {})
         uri = URI(url)
         @connection = PuppetX::Bodeco.const_get(uri.scheme.upcase).new("#{uri.scheme}://#{uri.host}:#{uri.port}", options)
-        @connection.download("#{uri.path}?#{uri.query}", filepath)
+        if uri.query.nil? or uri.query.empty?
+          @connection.download("#{uri.path}", filepath)
+        else
+          @connection.download("#{uri.path}?#{uri.query}", filepath)
+        end
       end
 
       def self.content(url, filepath, options = {})
         uri = URI(url)
         @connection = PuppetX::Bodeco.const_get(uri.scheme.upcase).new("#{uri.scheme}://#{uri.host}:#{uri.port}", options)
-        @connection.content("#{uri.path}?#{uri.query}")
+        if uri.query.nil? or uri.query.empty?
+          @connection.content("#{uri.path}")
+        else
+          @connection.content("#{uri.path}?#{uri.query}")
+        end
       end
     end
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,10 +2,12 @@
 class archive::params {
   case $::osfamily {
     default: {
-      $path  = '/opt/staging'
-      $owner = '0'
-      $group = '0'
-      $mode  = '0640'
+      $path               = '/opt/staging'
+      $owner              = '0'
+      $group              = '0'
+      $mode               = '0640'
+      $seven_zip_name     = undef
+      $seven_zip_provider = undef
     }
     'Windows': {
       $path               = $::staging_windir


### PR DESCRIPTION
When setting  "strict_variables = true", which will become the default in puppet 5, referencing unassigned variables will abort compilation.
