### PR TITLE
Added support for puppet_gem required by the AIO agent

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,8 @@ class archive::params {
 
   if $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
     $gem_provider = 'pe_gem'
+  } elsif pick($::aio_agent_version,false) {
+    $gem_provider = 'puppet_gem'
   } else {
     $gem_provider = 'gem'
   }


### PR DESCRIPTION
The AIO agent uses `puppet_gem` as its gem provider so we need to be able to deal with that
