### PR TITLE
gem provider check fixed for Puppet Enterprise 2015.2 and Puppet OSS 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,9 +17,16 @@ class archive::params {
     }
   }
 
-  if $::puppetversion =~ /Puppet Enterprise/ and $::osfamily != 'Windows' {
-    $gem_provider = 'pe_gem'
-  } else {
-    $gem_provider = 'gem'
+# from https://tickets.puppetlabs.com/browse/MODULES-2279
+  if $aio_agent_version {
+      # the master version is irrelevant here, all AIO agents will use this
+      $gem_provider = 'puppet_gem'
   }
+  elsif str2bool($is_pe) and $::osfamily != 'Windows' {
+      $gem_provider = 'pe_gem'
+  }
+  else {
+      $gem_provider = 'gem'
+  }
+
 }


### PR DESCRIPTION
Check what gem provider to use has been changed, see Ticket MODULES-2279
(https://tickets.puppetlabs.com/browse/MODULES-2279). Will work for PE 2015.02
